### PR TITLE
Add support to Intelij 232+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion = 0.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223
-pluginUntilBuild = 231.*
+pluginUntilBuild = 232.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IC


### PR DESCRIPTION
JetBrains has released a new version of Injellij: Build #IU-232.8660.185, built on July 26, 2023
This PR adds support to intellij's latest version.