### PR TITLE
Add configuration.validation schema support

### DIFF
--- a/docs-site/docs/features/hover-docs.mdx
+++ b/docs-site/docs/features/hover-docs.mdx
@@ -118,6 +118,9 @@ Hovering over any Concord YAML key shows a description of that key's purpose in 
 ```concord
 configuration:      # Hover: process configuration
   entryPoint: main  # Hover: flow to run on process start
+  validation:
+    taskCalls:
+      in: fail      # Hover: validation mode for task input parameters
 
 flows:
   main:

--- a/docs-site/docs/features/validation.mdx
+++ b/docs-site/docs/features/validation.mdx
@@ -58,6 +58,32 @@ flows:
     - log: "Hello, ${userName}"
 ```
 
+### Concord Runtime Validation Settings
+The plugin understands Concord's `configuration.validation` settings for task call parameter validation, both at the top level and inside profile-specific configuration blocks.
+
+```concord
+configuration:
+  validation:
+    taskCalls:
+      in: fail
+      out: warn
+```
+
+Supported validation modes are:
+
+| Mode       | Behavior                                             |
+|------------|------------------------------------------------------|
+| `disabled` | Do not validate task call parameters                 |
+| `warn`     | Report validation problems as warnings               |
+| `fail`     | Fail the process when validation errors are found    |
+
+The schema applies to these keys:
+
+| Key                                      | Description                                  |
+|------------------------------------------|----------------------------------------------|
+| `configuration.validation.taskCalls.in`  | Validation mode for task input parameters    |
+| `configuration.validation.taskCalls.out` | Validation mode for task output parameters   |
+
 ## How to Configure
 
 Validation is implemented as standard IntelliJ inspections. You can customize their severity or disable them entirely:

--- a/docs-site/src/theme/prism-include-languages.js
+++ b/docs-site/src/theme/prism-include-languages.js
@@ -18,7 +18,7 @@ module.exports = function prismIncludeLanguages(Prism) {
       alias: ['step'],
     },
     dslKey: {
-      pattern: /\b(runtime|in|out|meta|method|body|headers|auth|debug|entryPoint|arguments|exclusive|tasks|dependencies)\b(?=\s*:)/m,
+      pattern: /\b(runtime|in|out|meta|method|body|headers|auth|debug|entryPoint|arguments|exclusive|tasks|dependencies|validation|taskCalls)\b(?=\s*:)/m,
       alias: ['dsl-key'],
     },
     expression: {

--- a/src/main/java/brig/concord/meta/model/ConfigurationMetaType.java
+++ b/src/main/java/brig/concord/meta/model/ConfigurationMetaType.java
@@ -35,7 +35,8 @@ public class ConfigurationMetaType extends ConcordMetaType implements HighlightP
             Map.entry("exclusive", ProcessExclusiveMetaType.getInstance()),
             Map.entry("out", new StringArrayMetaType(descKey("doc.configuration.out.description"))),
             Map.entry("template", new StringMetaType(descKey("doc.configuration.template.description"))),
-            Map.entry("parallelLoopParallelism", new IntegerMetaType(descKey("doc.configuration.parallelLoopParallelism.description")))
+            Map.entry("parallelLoopParallelism", new IntegerMetaType(descKey("doc.configuration.parallelLoopParallelism.description"))),
+            Map.entry("validation", ValidationMetaType.getInstance())
     );
 
     private ConfigurationMetaType() {

--- a/src/main/java/brig/concord/meta/model/ProfileConfigurationMetaType.java
+++ b/src/main/java/brig/concord/meta/model/ProfileConfigurationMetaType.java
@@ -35,7 +35,8 @@ public class ProfileConfigurationMetaType extends ConcordMetaType implements Hig
             Map.entry("exclusive", ProcessExclusiveMetaType.getInstance()),
             Map.entry("out", new StringArrayMetaType(descKey("doc.configuration.out.description"))),
             Map.entry("template", new StringMetaType(descKey("doc.configuration.template.description"))),
-            Map.entry("parallelLoopParallelism", new IntegerMetaType(descKey("doc.configuration.parallelLoopParallelism.description")))
+            Map.entry("parallelLoopParallelism", new IntegerMetaType(descKey("doc.configuration.parallelLoopParallelism.description"))),
+            Map.entry("validation", ValidationMetaType.getInstance())
     );
 
     public static ProfileConfigurationMetaType getInstance() {

--- a/src/main/java/brig/concord/meta/model/ValidationMetaType.java
+++ b/src/main/java/brig/concord/meta/model/ValidationMetaType.java
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+package brig.concord.meta.model;
+
+import brig.concord.ConcordBundle;
+import brig.concord.highlighting.ConcordHighlightingColors;
+import brig.concord.meta.ConcordMetaType;
+import brig.concord.meta.HighlightProvider;
+import brig.concord.yaml.meta.model.TypeProps;
+import brig.concord.yaml.meta.model.YamlEnumType;
+import brig.concord.yaml.meta.model.YamlMetaType;
+import brig.concord.yaml.psi.YAMLScalar;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+import static brig.concord.yaml.meta.model.TypeProps.descKey;
+
+public class ValidationMetaType extends ConcordMetaType implements HighlightProvider {
+
+    private static final ValidationMetaType INSTANCE = new ValidationMetaType();
+
+    private static final Map<String, YamlMetaType> features = Map.of(
+            "taskCalls", TaskCallValidationMetaType.getInstance()
+    );
+
+    public static ValidationMetaType getInstance() {
+        return INSTANCE;
+    }
+
+    private ValidationMetaType() {
+        super(descKey("doc.configuration.validation.description"));
+    }
+
+    @Override
+    protected @NotNull Map<String, YamlMetaType> getFeatures() {
+        return features;
+    }
+
+    @Override
+    public @Nullable TextAttributesKey getKeyHighlight(String key) {
+        return ConcordHighlightingColors.DSL_KEY;
+    }
+
+    @Override
+    public @Nullable String getDocumentationExample() {
+        return """
+                configuration:
+                  validation:
+                    taskCalls:
+                      in: fail
+                      out: warn
+                """;
+    }
+
+    private static class TaskCallValidationMetaType extends ConcordMetaType implements HighlightProvider {
+
+        private static final TaskCallValidationMetaType INSTANCE = new TaskCallValidationMetaType();
+
+        private static final Map<String, YamlMetaType> features = Map.of(
+                "in", new ValidationModeMetaType(descKey("doc.configuration.validation.taskCalls.in.description")),
+                "out", new ValidationModeMetaType(descKey("doc.configuration.validation.taskCalls.out.description"))
+        );
+
+        public static TaskCallValidationMetaType getInstance() {
+            return INSTANCE;
+        }
+
+        private TaskCallValidationMetaType() {
+            super(descKey("doc.configuration.validation.taskCalls.description"));
+        }
+
+        @Override
+        protected @NotNull Map<String, YamlMetaType> getFeatures() {
+            return features;
+        }
+
+        @Override
+        public @Nullable TextAttributesKey getKeyHighlight(String key) {
+            return ConcordHighlightingColors.DSL_KEY;
+        }
+    }
+
+    private static class ValidationModeMetaType extends YamlEnumType {
+
+        private ValidationModeMetaType(@NotNull TypeProps props) {
+            super("string", props,
+                    List.of(
+                            EnumValue.ofKey("disabled", "doc.configuration.validation.mode.disabled.description"),
+                            EnumValue.ofKey("warn", "doc.configuration.validation.mode.warn.description"),
+                            EnumValue.ofKey("fail", "doc.configuration.validation.mode.fail.description")));
+        }
+
+        @Override
+        protected void validateScalarValue(@NotNull YAMLScalar scalarValue, @NotNull ProblemsHolder holder) {
+            var text = scalarValue.getTextValue();
+            if (text.isEmpty()) {
+                return;
+            }
+
+            if (getLiteralsStream().noneMatch(literal -> literal.equalsIgnoreCase(text))) {
+                holder.registerProblem(scalarValue,
+                        ConcordBundle.message("YamlEnumType.validation.error.value.unknown", text),
+                        ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
+            }
+        }
+    }
+}

--- a/src/main/resources/messages/ConcordBundle.properties
+++ b/src/main/resources/messages/ConcordBundle.properties
@@ -54,6 +54,13 @@ doc.configuration.exclusive.description=Ensures only one process runs per <b>pro
 doc.configuration.out.description=List of variables to return as process output
 doc.configuration.template.description=Name of the template to apply to this process
 doc.configuration.parallelLoopParallelism.description=Maximum number of parallel threads for parallel loops
+doc.configuration.validation.description=Configures process validation behavior
+doc.configuration.validation.taskCalls.description=Validation settings for task call input and output parameters
+doc.configuration.validation.taskCalls.in.description=Validation mode for task input parameters
+doc.configuration.validation.taskCalls.out.description=Validation mode for task output parameters
+doc.configuration.validation.mode.disabled.description=No validation
+doc.configuration.validation.mode.warn.description=Log warnings but continue
+doc.configuration.validation.mode.fail.description=Fail on validation errors
 
 doc.flows.description=Flow definitions. Each key is a flow name mapping to a list of steps
 doc.flows.flowName.description=Flow definition. A list of steps that Concord executes

--- a/src/test/java/brig/concord/documentation/ConfigurationDocumentationTest.java
+++ b/src/test/java/brig/concord/documentation/ConfigurationDocumentationTest.java
@@ -47,7 +47,11 @@ public class ConfigurationDocumentationTest extends BaseDocumentationTargetTest 
                       - "password"
                       - "privateKey"
                       - "vaultPassword"
-                    outVarsBlacklist: []""");
+                    outVarsBlacklist: []
+                  validation:
+                    taskCalls:
+                      in: fail
+                      out: warn""");
 
         assertDocTarget(key("/configuration"), "doc.configuration.description",
                 "/documentation/configuation.html");
@@ -119,5 +123,14 @@ public class ConfigurationDocumentationTest extends BaseDocumentationTargetTest 
                 "/documentation/configuation.events.inVarsBlacklist.html");
         assertDocTarget(key("/configuration/events/outVarsBlacklist"), "doc.configuration.events.outVarsBlacklist.description",
                 "/documentation/configuation.events.outVarsBlacklist.html");
+
+        assertDocTarget(key("/configuration/validation"), "doc.configuration.validation.description",
+                "/documentation/configuation.validation.html");
+        assertDocTarget(key("/configuration/validation/taskCalls"), "doc.configuration.validation.taskCalls.description",
+                "/documentation/configuation.validation.taskCalls.html");
+        assertDocTarget(key("/configuration/validation/taskCalls/in"), "doc.configuration.validation.taskCalls.in.description",
+                "/documentation/configuation.validation.taskCalls.in.html");
+        assertDocTarget(key("/configuration/validation/taskCalls/out"), "doc.configuration.validation.taskCalls.out.description",
+                "/documentation/configuation.validation.taskCalls.out.html");
     }
 }

--- a/src/test/java/brig/concord/highlighting/ConfigurationHighlightingTest.java
+++ b/src/test/java/brig/concord/highlighting/ConfigurationHighlightingTest.java
@@ -73,5 +73,10 @@ class ConfigurationHighlightingTest extends HighlightingTestBase {
         highlight(key("/configuration/events/inVarsBlacklist")).is(ConcordHighlightingColors.DSL_KEY);
         highlight(key("/configuration/events/metaBlacklist")).is(ConcordHighlightingColors.DSL_KEY);
         highlight(key("/configuration/events/outVarsBlacklist")).is(ConcordHighlightingColors.DSL_KEY);
+
+        highlight(key("/configuration/validation")).is(ConcordHighlightingColors.DSL_KEY);
+        highlight(key("/configuration/validation/taskCalls")).is(ConcordHighlightingColors.DSL_KEY);
+        highlight(key("/configuration/validation/taskCalls/in")).is(ConcordHighlightingColors.DSL_KEY);
+        highlight(key("/configuration/validation/taskCalls/out")).is(ConcordHighlightingColors.DSL_KEY);
     }
 }

--- a/src/test/java/brig/concord/inspection/ErrorInspectionTests.java
+++ b/src/test/java/brig/concord/inspection/ErrorInspectionTests.java
@@ -333,7 +333,12 @@ class ErrorInspectionTests extends InspectionTestBase {
                 args("020", a -> a.assertSingleValueExpected().assertSingleValueExpected()),
                 args("021", a -> a.assertUnexpectedValue("1")),
                 args("022", InspectionAssertions::assertArrayRequired),
-                args("023", InspectionAssertions::assertDurationExpected)
+                args("023", InspectionAssertions::assertDurationExpected),
+                args("024", InspectionAssertions::assertObjectRequired),
+                args("025", InspectionAssertions::assertObjectRequired),
+                args("026", a -> a.assertUnexpectedValue("oops")),
+                args("027", a -> a.assertUnknownKey("trash")),
+                args("028", a -> a.assertUnknownKey("trash"))
         );
     }
 

--- a/src/test/resources/documentation/configuation.html
+++ b/src/test/resources/documentation/configuation.html
@@ -37,5 +37,6 @@
             (format: ISO 8601 duration)
         </li>
         <li><code>template</code> <i>(string)</i> &mdash; name of the template to apply to this process</li>
+        <li><code>validation</code> <i>(object)</i> &mdash; configures process validation behavior</li>
     </ul>
 </div>

--- a/src/test/resources/documentation/configuation.validation.html
+++ b/src/test/resources/documentation/configuation.validation.html
@@ -1,0 +1,19 @@
+<div class='definition'>
+    <pre>validation</pre>
+</div>
+<div class='content'><p>Type: <code>object</code></p>
+    <p>Configures process validation behavior</p>
+    <p><b>Keys:</b></p>
+    <ul>
+        <li><code>taskCalls</code> <i>(object)</i> &mdash; validation settings for task call input and output
+            parameters
+        </li>
+    </ul>
+    <p><b>Example:</b></p>
+    <pre><code>configuration:
+  validation:
+    taskCalls:
+      in: fail
+      out: warn
+</code></pre>
+</div>

--- a/src/test/resources/documentation/configuation.validation.taskCalls.html
+++ b/src/test/resources/documentation/configuation.validation.taskCalls.html
@@ -1,0 +1,23 @@
+<div class='definition'>
+    <pre>taskCalls</pre>
+</div>
+<div class='content'><p>Type: <code>object</code></p>
+    <p>Validation settings for task call input and output parameters</p>
+    <p><b>Keys:</b></p>
+    <ul>
+        <li><code>in</code> <i>(string)</i> &mdash; validation mode for task input parameters
+            <ul>
+                <li><code>disabled</code> &mdash; no validation</li>
+                <li><code>warn</code> &mdash; log warnings but continue</li>
+                <li><code>fail</code> &mdash; fail on validation errors</li>
+            </ul>
+        </li>
+        <li><code>out</code> <i>(string)</i> &mdash; validation mode for task output parameters
+            <ul>
+                <li><code>disabled</code> &mdash; no validation</li>
+                <li><code>warn</code> &mdash; log warnings but continue</li>
+                <li><code>fail</code> &mdash; fail on validation errors</li>
+            </ul>
+        </li>
+    </ul>
+</div>

--- a/src/test/resources/documentation/configuation.validation.taskCalls.in.html
+++ b/src/test/resources/documentation/configuation.validation.taskCalls.in.html
@@ -1,0 +1,12 @@
+<div class='definition'>
+    <pre>in</pre>
+</div>
+<div class='content'><p>Type: <code>string</code></p>
+    <p>Validation mode for task input parameters</p>
+    <p><b>Values:</b></p>
+    <ul>
+        <li><code>disabled</code> <i>(string)</i> &mdash; no validation</li>
+        <li><code>warn</code> <i>(string)</i> &mdash; log warnings but continue</li>
+        <li><code>fail</code> <i>(string)</i> &mdash; fail on validation errors</li>
+    </ul>
+</div>

--- a/src/test/resources/documentation/configuation.validation.taskCalls.out.html
+++ b/src/test/resources/documentation/configuation.validation.taskCalls.out.html
@@ -1,0 +1,12 @@
+<div class='definition'>
+    <pre>out</pre>
+</div>
+<div class='content'><p>Type: <code>string</code></p>
+    <p>Validation mode for task output parameters</p>
+    <p><b>Values:</b></p>
+    <ul>
+        <li><code>disabled</code> <i>(string)</i> &mdash; no validation</li>
+        <li><code>warn</code> <i>(string)</i> &mdash; log warnings but continue</li>
+        <li><code>fail</code> <i>(string)</i> &mdash; fail on validation errors</li>
+    </ul>
+</div>

--- a/src/test/resources/documentation/profiles.profileName.configuration.html
+++ b/src/test/resources/documentation/profiles.profileName.configuration.html
@@ -38,5 +38,6 @@
             (format: ISO 8601 duration)
         </li>
         <li><code>template</code> <i>(string)</i> &mdash; name of the template to apply to this process</li>
+        <li><code>validation</code> <i>(object)</i> &mdash; configures process validation behavior</li>
     </ul>
 </div>

--- a/src/test/resources/errors/configuration/024.concord.yml
+++ b/src/test/resources/errors/configuration/024.concord.yml
@@ -1,0 +1,2 @@
+configuration:
+  validation: 1

--- a/src/test/resources/errors/configuration/025.concord.yml
+++ b/src/test/resources/errors/configuration/025.concord.yml
@@ -1,0 +1,3 @@
+configuration:
+  validation:
+    taskCalls: 1

--- a/src/test/resources/errors/configuration/026.concord.yml
+++ b/src/test/resources/errors/configuration/026.concord.yml
@@ -1,0 +1,4 @@
+configuration:
+  validation:
+    taskCalls:
+      in: oops

--- a/src/test/resources/errors/configuration/027.concord.yml
+++ b/src/test/resources/errors/configuration/027.concord.yml
@@ -1,0 +1,3 @@
+configuration:
+  validation:
+    trash: true

--- a/src/test/resources/errors/configuration/028.concord.yml
+++ b/src/test/resources/errors/configuration/028.concord.yml
@@ -1,0 +1,4 @@
+configuration:
+  validation:
+    taskCalls:
+      trash: true

--- a/src/test/resources/highlighting/configuration.concord.yaml
+++ b/src/test/resources/highlighting/configuration.concord.yaml
@@ -36,3 +36,7 @@ configuration:
       - "meta1"
     outVarsBlacklist:
       - "out1"
+  validation:
+    taskCalls:
+      in: fail
+      out: warn

--- a/src/test/resources/ok/configuration/000.concord.yml
+++ b/src/test/resources/ok/configuration/000.concord.yml
@@ -42,6 +42,10 @@ configuration:
     truncateMeta: true
     truncateOutVars: true
     updateMetaOnAllEvents: true
+  validation:
+    taskCalls:
+      in: fail
+      out: WARN
 
 flows:
   main-test:


### PR DESCRIPTION
## Summary
- add Concord YAML metadata for `configuration.validation.taskCalls.in/out`
- accept validation modes `disabled`, `warn`, and `fail` case-insensitively, matching walmartlabs/concord@c0e2399c45d3e76a2179870adedeb09f34b56cb0
- add inspection, highlighting, and documentation coverage for the new keys
- update docs-site pages and Concord syntax highlighting examples for the new config block

## Tests
- `./gradlew :test --tests brig.concord.documentation.ConfigurationDocumentationTest --tests brig.concord.documentation.ProfilesDocumentationTest --tests brig.concord.highlighting.ConfigurationHighlightingTest --tests brig.concord.inspection.ErrorInspectionTests --tests brig.concord.inspection.OkInspectionTests --rerun-tasks`
- `./gradlew :test`
- `npm ci` in `docs-site`
- `npm run build` in `docs-site`