### PR TITLE
Fix NPE when CLI version detection exception has null message

### DIFF
--- a/src/main/java/brig/concord/run/cli/ConcordCliManager.java
+++ b/src/main/java/brig/concord/run/cli/ConcordCliManager.java
@@ -201,8 +201,9 @@ public final class ConcordCliManager {
             LOG.warn("CLI version detection failed: " + detail);
             return VersionResult.failure(detail);
         } catch (Exception e) {
-            LOG.warn("Failed to detect CLI version: " + e.getMessage());
-            return VersionResult.failure(e.getMessage());
+            LOG.warn("Failed to detect CLI version: " + e.getMessage(), e);
+            var message = e.getMessage();
+            return VersionResult.failure(message != null ? message : e.getClass().getSimpleName());
         } finally {
             if (process != null && process.isAlive()) {
                 process.destroyForcibly();


### PR DESCRIPTION
## Summary
- `ConcordCliManager.detectCliVersion` passed `e.getMessage()` directly to `VersionResult.failure(@NotNull String)`, throwing `IllegalArgumentException` when the underlying exception had no message (observed when opening a new project in a new IDE window).
- Fall back to the exception class simple name when the message is null, and pass the throwable to the logger for diagnostics.

## Test plan
- [ ] Open a new project in a new IntelliJ window with Concord plugin installed and confirm no `IllegalArgumentException` from `ConcordCliManager\$VersionResult.failure` in the IDE log.